### PR TITLE
fix cartopy install

### DIFF
--- a/12-Geospatial-Data/12.1 Map Projections and Distance Metrics.ipynb
+++ b/12-Geospatial-Data/12.1 Map Projections and Distance Metrics.ipynb
@@ -191,7 +191,8 @@
       "source": [
         "# I had to uninstall Shapely to get this to work in Colab.\n",
         "!pip uninstall -y shapely\n",
-        "!apt-get -qq install python-cartopy python3-cartopy"
+        "!apt-get -qq install python-cartopy python3-cartopy",
+        "!pip install cartopy==0.18.0"
       ],
       "execution_count": 0,
       "outputs": []

--- a/12-Geospatial-Data/12.1 Map Projections and Distance Metrics.ipynb
+++ b/12-Geospatial-Data/12.1 Map Projections and Distance Metrics.ipynb
@@ -191,7 +191,7 @@
       "source": [
         "# I had to uninstall Shapely to get this to work in Colab.\n",
         "!pip uninstall -y shapely\n",
-        "!apt-get -qq install python-cartopy python3-cartopy",
+        "!apt-get -qq install python-cartopy python3-cartopy\n",
         "!pip install cartopy==0.18.0"
       ],
       "execution_count": 0,


### PR DESCRIPTION
It looks like the new version of cartopy - which is necessary to get the import to work - can be installed with pip.

I left the original "apt-get" install in there too just in case.